### PR TITLE
remove automodule:: pyqubo

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,5 +1,3 @@
-.. automodule:: pyqubo
-
 Getting Started
 ===============
 

--- a/docs/reference/array.rst
+++ b/docs/reference/array.rst
@@ -1,6 +1,5 @@
 :orphan:
 
-.. automodule:: pyqubo.array
 .. currentmodule:: pyqubo
 
 Array

--- a/docs/reference/constraint.rst
+++ b/docs/reference/constraint.rst
@@ -2,7 +2,6 @@ Logical Constraint
 ==================
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 NOT Constraint

--- a/docs/reference/express.rst
+++ b/docs/reference/express.rst
@@ -1,7 +1,6 @@
 Expression
 ==========
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 .. autoclass:: Express

--- a/docs/reference/func.rst
+++ b/docs/reference/func.rst
@@ -2,7 +2,6 @@ Functions
 =========
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 Sum over indices

--- a/docs/reference/integer.rst
+++ b/docs/reference/integer.rst
@@ -1,6 +1,5 @@
 :orphan:
 
-.. automodule:: pyqubo.integer
 .. currentmodule:: pyqubo
 
 Integer

--- a/docs/reference/internal/binaryprod.rst
+++ b/docs/reference/internal/binaryprod.rst
@@ -2,7 +2,6 @@ BinaryProd
 ==========
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 .. autoclass:: BinaryProd

--- a/docs/reference/internal/coefficient.rst
+++ b/docs/reference/internal/coefficient.rst
@@ -2,7 +2,6 @@ Coefficient
 ===========
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 .. autoclass:: Coefficient

--- a/docs/reference/internal/compiledconstraint.rst
+++ b/docs/reference/internal/compiledconstraint.rst
@@ -2,7 +2,6 @@ CompiledConstraint
 ==================
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 .. autoclass:: CompiledConstraint

--- a/docs/reference/internal/compiledqubo.rst
+++ b/docs/reference/internal/compiledqubo.rst
@@ -2,7 +2,6 @@ CompiledQubo
 ============
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 .. autoclass:: CompiledQubo

--- a/docs/reference/internal/placeholderprod.rst
+++ b/docs/reference/internal/placeholderprod.rst
@@ -2,7 +2,6 @@ PlaceholderProd
 ===============
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 .. autoclass:: PlaceholderProd

--- a/docs/reference/logic.rst
+++ b/docs/reference/logic.rst
@@ -2,7 +2,6 @@ Logical Gate
 ============
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 Not

--- a/docs/reference/model.rst
+++ b/docs/reference/model.rst
@@ -2,7 +2,6 @@ Model
 =======
 
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 .. autoclass:: Model

--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -1,7 +1,6 @@
 Utils
 =====
 
-.. automodule:: pyqubo
 .. currentmodule:: pyqubo
 
 


### PR DESCRIPTION
I removed `automodule:: pyqubo` directive from rst file to fix the build error seen in #46 and #45.