### PR TITLE
Optimize CompiledQubo.variables

### DIFF
--- a/pyqubo/core/compiled_qubo.py
+++ b/pyqubo/core/compiled_qubo.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from operator import or_
 import dimod
-from six.moves import reduce
 
 
 class CompiledQubo:
@@ -40,7 +38,11 @@ class CompiledQubo:
     @property
     def variables(self):
         """Unique labels contained in keys of QUBO."""
-        return reduce(or_, [{i, j} for (i, j) in self.qubo.keys()])
+        indices = set()
+        for (i, j) in self.qubo.keys():
+            indices.add(i)
+            indices.add(j)
+        return list(indices)
 
     def evaluate(self, feed_dict):
         """Returns QUBO where the values are evaluated with feed_dict.


### PR DESCRIPTION
I figured out that more than 90% of the compile time is consumed by CompiledQubo.variables
https://github.com/recruit-communications/pyqubo/blob/0466e4b4fab640791b6d4e70404a99efe12a55e5/pyqubo/core/compiled_qubo.py#L43

To optimize this part, I stop using `reduce`.

As a result,  computation time of this part has become negligible.