### PR TITLE
Fix parameter name for neal (sweeps -> num_sweeps)

### DIFF
--- a/pyqubo/utils/solver.py
+++ b/pyqubo/utils/solver.py
@@ -42,7 +42,7 @@ def solve_qubo(qubo, num_reads=10, sweeps=1000, beta_range=(1.0, 50.0)):
     scale_qubo = {k: float(v) / max_abs_value for k, v in qubo.items()}
     sa = neal.SimulatedAnnealingSampler()
     sa_computation = sa.sample_qubo(scale_qubo, num_reads=num_reads,
-                                    sweeps=sweeps, beta_range=beta_range)
+                                    num_sweeps=sweeps, beta_range=beta_range)
     best = np.argmin(sa_computation.record.energy)
     best_solution = list(sa_computation.record.sample[best])
     return dict(zip(sa_computation.variables, best_solution))
@@ -77,7 +77,7 @@ def solve_ising(linear, quad, num_reads=10, sweeps=1000, beta_range=(1.0, 50.0))
     scale_quad = {k: float(v) / max_abs_value for k, v in quad.items()}
     sa = neal.SimulatedAnnealingSampler()
     sa_computation = sa.sample_ising(scale_linear, scale_quad, num_reads=num_reads,
-                                     sweeps=sweeps, beta_range=beta_range)
+                                     num_sweeps=sweeps, beta_range=beta_range)
     best = np.argmin(sa_computation.record.energy)
     best_solution = list(sa_computation.record.sample[best])
     return dict(zip(sa_computation.variables, best_solution))


### PR DESCRIPTION
I got the following warning, when I perform a unit test of `test_solver.py`. The 'sweeps' parameter seems to be deprecated now. This PR fixes it to `num_sweeps`.
```
site-packages/neal/sampler.py:222: DeprecationWarning: The 'sweeps' parameter is deprecated in favor of 'num_sweeps'.
  "favor of 'num_sweeps'.", DeprecationWarning)
```