### PR TITLE
Improve performance of the __add__ operation of AddList

### DIFF
--- a/pyqubo/core/express.py
+++ b/pyqubo/core/express.py
@@ -823,7 +823,7 @@ class AddList(Express):
     def __add__(self, other):
         """ Override __add__().
         
-        To prevent a deep nested expression, __add__() returns AddList object
+        To prevent a deep nested expression, __add__() returns AddList object itself
         where the added expression object is appended to :obj:`terms`.
         
         Returns:
@@ -834,7 +834,8 @@ class AddList(Express):
         else:
             if not isinstance(other, Express):
                 other = Num(other)
-            return AddList(self.terms + [other])
+            self.terms.append(other)
+            return self
 
     def __hash__(self):
         return reduce(xor, [hash(term) for term in self.terms])
@@ -878,4 +879,3 @@ class Num(Express):
             return False
         else:
             return self.value == other.value
-

--- a/pyqubo/core/express.py
+++ b/pyqubo/core/express.py
@@ -810,20 +810,23 @@ class AddList(Express):
         (Binary(a)+Binary(b))
     """
 
-    def __init__(self, terms):
+    def __init__(self, terms, skip_terms_check=False):
         super(AddList, self).__init__()
-        new_terms = []
-        for term in terms:
-            if isinstance(term, Express):
-                new_terms.append(term)
-            else:
-                new_terms.append(Num(term))
-        self.terms = new_terms
+        if skip_terms_check:
+            self.terms = terms
+        else:
+            new_terms = []
+            for term in terms:
+                if isinstance(term, Express):
+                    new_terms.append(term)
+                else:
+                    new_terms.append(Num(term))
+            self.terms = new_terms
 
     def __add__(self, other):
         """ Override __add__().
         
-        To prevent a deep nested expression, __add__() returns AddList object itself
+        To prevent a deep nested expression, __add__() returns AddList object
         where the added expression object is appended to :obj:`terms`.
         
         Returns:
@@ -834,8 +837,7 @@ class AddList(Express):
         else:
             if not isinstance(other, Express):
                 other = Num(other)
-            self.terms.append(other)
-            return self
+            return AddList(self.terms + [other], skip_terms_check=True)
 
     def __hash__(self):
         return reduce(xor, [hash(term) for term in self.terms])


### PR DESCRIPTION
The `__add__` operation of AddList is slow, because a new AddList object is generated each time. When we generate a new AddList, each element in a given list is scanned in the constructor of the AddList class. However, this is a huge overhead cost when we try to add something to a huge AddList object. This PR fixes to return AddList object itself instead of generating a new AddList object every time. I believe the behavior does not change by this update.

**Performance improvement:**
I try to construct 10000 binary variables (this is a typical size order when I formulate a problem) like in the following snippet. The performance improved as follows:

- Currently: 46.370 sec
- After this fix: 0.033 sec (x1400 faster in this case)

Snippet:
```
vars = []
for i in range(10000):
    vars.append(Binary("x{}".format(i)))

import time
start = time.time()
exp = 0.0
for v in vars:
    exp += v
print('elapsed: {} sec'.format(time.time() - start))
```