### PR TITLE
Integer類のdocstringの修正とrequirements.txtについて

### DIFF
--- a/pyqubo/integer/log_encoded_integer.py
+++ b/pyqubo/integer/log_encoded_integer.py
@@ -19,7 +19,7 @@ import numpy as np
 
 class LogEncInteger(Integer):
     """Log encoded integer. The value that takes :math:`[0, n]` is
-    represented by :math:`\\sum_{i=1}^{\\lceil\\log_{2}n\\rceil}2^ix_{i}` without any constraint.
+    represented by :math:`\\sum_{i=0}^{\\lfloor\\log_{2}n\\rfloor}2^ix_{i}` without any constraint.
 
     Args:
         label (str): Label of the integer.

--- a/pyqubo/integer/one_hot_enc_integer.py
+++ b/pyqubo/integer/one_hot_enc_integer.py
@@ -19,7 +19,7 @@ from pyqubo.core.express import WithPenalty, Placeholder
 
 
 class OneHotEncInteger(WithPenalty, Integer):
-    """One-hot encoded integer. The value that takes :math:`[0, n]` is represented by :math:`\sum_{i=1}^{n}ix_{i}`.
+    """One-hot encoded integer. The value that takes :math:`[1, n]` is represented by :math:`\sum_{i=1}^{n}ix_{i}`.
     Also we have the penalty function :math:`strength \\times (\sum_{i=1}^{n}x_{i}-1)^2` in the Hamiltonian.
     
     Args:
@@ -36,7 +36,7 @@ class OneHotEncInteger(WithPenalty, Integer):
         
         .. math::
         
-            H = \\left(\\left(\sum_{i=1}^{3}ia_{i}+1\\right) - 2\\right)^2 + strength \\times \\left(\sum_{i=1}^{3}a_{i}-1\\right)^2
+            H = \\left(\sum_{i=1}^{3}ia_{i} - 2\\right)^2 + strength \\times \\left(\sum_{i=1}^{3}a_{i}-1\\right)^2
         
         >>> from pyqubo import OneHotEncInteger
         >>> a = OneHotEncInteger("a", 1, 3, strength=5)

--- a/pyqubo/integer/unary_encoded_integer.py
+++ b/pyqubo/integer/unary_encoded_integer.py
@@ -28,14 +28,14 @@ class UnaryEncInteger(Integer):
         upper (int): Upper value of the integer.
 
     Examples:
-        This example finds the value `a`, `b` such that :math:`a+b=3` and :math:`2a-b=1`.
+        This example finds the value `a`, `b` such that :math:`a+b=3` and :math:`3a-b=1`.
         
         >>> from pyqubo import UnaryEncInteger
         >>> import dimod
         >>> a = UnaryEncInteger("a", 0, 3)
         >>> b = UnaryEncInteger("b", 0, 3)
         >>> M=2.0
-        >>> H = (2*a-b-1)**2 + M*(a+b-3)**2
+        >>> H = (3*a-b-1)**2 + M*(a+b-3)**2
         >>> model = H.compile()
         >>> q, offset = model.to_qubo()
         >>> sampleset = dimod.ExactSolver().sample_qubo(q)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dimod>=0.8.4
-numpy==1.15.1
+numpy==1.15.1;python_version<'3.5'
+numpy==1.17.3;python_version>='3.5'
 six==1.11.0
 coverage==4.5.1
 codecov==2.0.15


### PR DESCRIPTION
# Docstringの修正
非常に些細な点で恐縮ではございますが、integerのdocstringと実装が一部整合していないと思われるので、修正を行いました。
- LogEngIntegerの数式部分の添字が、2^1スタートとなっているが、2^0スタートであると思われる。
- OneHotEncIntegerは、何らかのx_iが1となるため（全て0にはなりえない）、値の範囲が[0, n]ではなく[1, n]であると思われる。
- OneHotEncIntegerのLaTeX数式が、実装と対応づいていないように思われる。
- unary_encoded_integerについて、docstring内の例題が、計算結果と合わないような例題となっている。（元の例では、a=4/3, b=5/3が答えであると思います。四捨五入すればa=1, b=2ですので、意図してのことでしたら大丈夫です。）

# Versionについて
dimodがsetup.py上にてnumpy>=1.16.0（requirements.txt上では1.17.3）を設定していますが、
pyquboのrequirements.txtではnumpy==1.15.1を要求していたため、dimod上でのエラーが生じ、CIが通っていないように見受けられました。
一方でnumpy1.16.0以降に変更した場合、numpy側の対応切れでPython2.7などからのインストールができない様子です。
暫定で動作するように、requirements.txtファイルを編集しました。

dimodの動作保証がPython3.5+となっている様子ですので、更に調整など必要なようでしたらご指摘ください。