### PR TITLE
update pybind11 (2.2.4 -> 2.5.0)

### DIFF
--- a/external/pybind11.cmake
+++ b/external/pybind11.cmake
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
     pybind11
     GIT_REPOSITORY  https://github.com/pybind/pybind11
-    GIT_TAG         v2.2.4
+    GIT_TAG         v2.5.0
 )
 
 FetchContent_GetProperties(pybind11)


### PR DESCRIPTION
# 問題報告

こちらの方でpyqubo>=1.0.0 とOpenJij (https://github.com/OpenJij/OpenJij) を同時にimportすると、linuxを使用した時にPythonがsegfaultでクラッシュする問題が起きる事象を確認しました。

# 原因

この原因はpybind11の旧バージョンに存在するバグであり、pybind11を用いた異なるバージョンのコンパイラでコンパイルされたモジュールを同時にimportするとSTLの互換性が取れないためにクラッシュするというものでした。ですので、OpenJijのみならず、pybind11を用いた他のライブラリと同時にimportしてもこの問題が発生する可能性があります。

関連するissueはこちらにあります。(https://github.com/pybind/pybind11/issues/1262)

# 解決手法

pybind11>=2.4.0 以降であればこの問題は解決されているため、ビルドに用いるライブラリを2.5.0にすることで解決できると思います。

手元の環境でmanylinux1を用いてwheelを生成してみましたが、問題なく動作することを確認しています。

よろしくおねがいします。
