### PR TITLE
Add constraints to final formulation

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -79,7 +79,7 @@ def tsp_with_timeout(n_city, timeout_sec):
         
         # Construct hamiltonian
         A = Placeholder("A")
-        H = distance
+        H = distance + A*(city_const+time_const)
 
         feed_dict["A"] = 1.0
 


### PR DESCRIPTION
The created constraints are missing from the final Hamiltonian, so they are not included in the `H.compile()` call.